### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
@@ -1,8 +1,10 @@
 package com.fastcampus.boardproject.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import com.fastcampus.boardproject.domain.ArticleComment;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
@@ -1,8 +1,10 @@
 package com.fastcampus.boardproject.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import com.fastcampus.boardproject.domain.Article;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,3 +21,6 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/src/test/java/com/fastcampus/boardproject/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/boardproject/controller/DataRestTest.java
@@ -1,0 +1,83 @@
+package com.fastcampus.boardproject.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+	private final MockMvc mvc;
+
+	public DataRestTest(@Autowired MockMvc mvc) {
+		this.mvc = mvc;
+	}
+
+	@DisplayName("[api] 게시글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articles"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 게시글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articles/1"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articles/1/articleComments"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articleComments"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articleComments/1"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST 로 서비스하고, 해당 api 들의 존재 여부만 체크하도록 통합테스트 작성