### PR TITLE
인증 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/boardproject/config/JpaConfig.java
+++ b/src/main/java/com/fastcampus/boardproject/config/JpaConfig.java
@@ -6,6 +6,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.fastcampus.boardproject.dto.security.BoardPrincipal;
 
 @EnableJpaAuditing
 @Configuration
@@ -13,6 +18,12 @@ public class JpaConfig {
 
 	@Bean
 	public AuditorAware<String> auditorAware() {
-		return () -> Optional.of("imhope"); // TODO: 스프링 시큐리티로 인증 기능을 붙이게 될 때, 수정하기
+		return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+				.map(SecurityContext::getAuthentication)
+				.filter(Authentication::isAuthenticated)
+				.map(Authentication::getPrincipal)
+				.map(BoardPrincipal.class::cast)
+				.map(BoardPrincipal::getUsername);
 	}
+
 }

--- a/src/main/java/com/fastcampus/boardproject/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/boardproject/config/SecurityConfig.java
@@ -1,9 +1,19 @@
 package com.fastcampus.boardproject.config;
 
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+
+import com.fastcampus.boardproject.dto.UserAccountDto;
+import com.fastcampus.boardproject.dto.security.BoardPrincipal;
+import com.fastcampus.boardproject.repository.UserAccountRepository;
 
 @Configuration
 public class SecurityConfig {
@@ -11,9 +21,39 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+						// static resource, css - js (spring security 관리를 받을 수 있음)
+						PathRequest.toStaticResources().atCommonLocations()
+				).permitAll()
+				.requestMatchers(
+						HttpMethod.GET,
+						"/",
+						"/articles",
+						"/articles/search-hashtag",
+						"/css"
+				).permitAll()
+				.anyRequest().authenticated()
+			)
 			.formLogin().and()
+			.logout()
+					.logoutSuccessUrl("/")
+					.and()
 			.build();
+	}
+
+	@Bean
+	public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+		return username -> userAccountRepository
+				.findById(username)
+				.map(UserAccountDto::from)
+				.map(BoardPrincipal::from)
+				.orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다. - username: " + username));
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
 	}
 
 }

--- a/src/main/java/com/fastcampus/boardproject/controller/ArticleCommentController.java
+++ b/src/main/java/com/fastcampus/boardproject/controller/ArticleCommentController.java
@@ -1,5 +1,6 @@
 package com.fastcampus.boardproject.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.fastcampus.boardproject.dto.UserAccountDto;
 import com.fastcampus.boardproject.dto.request.ArticleCommentRequest;
+import com.fastcampus.boardproject.dto.security.BoardPrincipal;
 import com.fastcampus.boardproject.service.ArticleCommentService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,18 +21,22 @@ public class ArticleCommentController {
 	private final ArticleCommentService articleCommentService;
 
 	@PostMapping("/new")
-	public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
-		// TODO : 인증 정보를 추가해야 한다.
-		articleCommentService.saveArticleComment(articleCommentRequest.toDto(UserAccountDto.of(
-			"imhope", "qwerasdf", "imhope@mail.com", "imhope", "memo"
-		)));
+	public String postNewArticleComment(
+			@AuthenticationPrincipal BoardPrincipal boardPrincipal,
+			ArticleCommentRequest articleCommentRequest
+	) {
+		articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
 
 		return "redirect:/articles/" + articleCommentRequest.articleId();
 	}
 
 	@PostMapping("/{commentId}/delete")
-	public String deleteArticleComment(@PathVariable Long commentId, Long articleId) {
-		articleCommentService.deleteArticleComment(commentId);
+	public String deleteArticleComment(
+			@PathVariable Long commentId,
+			@AuthenticationPrincipal BoardPrincipal boardPrincipal,
+			Long articleId
+	) {
+		articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
 
 		return "redirect:/articles/" + articleId;
 	}

--- a/src/main/java/com/fastcampus/boardproject/domain/Article.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/Article.java
@@ -64,8 +64,8 @@ public class Article extends AuditingFields {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (!(o instanceof Article article)) return false;
-		return id != null && id.equals(article.id);
+		if (!(o instanceof Article that)) return false;
+		return id != null && id.equals(that.getId());
 	}
 
 	@Override

--- a/src/main/java/com/fastcampus/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/ArticleComment.java
@@ -52,7 +52,7 @@ public class ArticleComment extends AuditingFields {
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (!(o instanceof ArticleComment that)) return false;
-		return id != null && id.equals(that.id);
+		return id != null && id.equals(that.getId());
 	}
 
 	@Override

--- a/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
@@ -54,8 +54,8 @@ public class UserAccount extends AuditingFields {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-		if (!(o instanceof UserAccount userAccount)) return false;
-		return userId != null && userId.equals(userAccount.userId);
+		if (!(o instanceof UserAccount that)) return false;
+		return userId != null && userId.equals(that.getUserId());
 	}
 
 	@Override

--- a/src/main/java/com/fastcampus/boardproject/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/boardproject/dto/response/ArticleCommentResponse.java
@@ -9,11 +9,12 @@ public record ArticleCommentResponse(
 		String content,
 		LocalDateTime createdAt,
 		String email,
-		String nickname
+		String nickname,
+		String userId
 ) {
 
-	public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-		return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+	public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+		return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
 	}
 
 	public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -27,7 +28,8 @@ public record ArticleCommentResponse(
 			dto.content(),
 			dto.createdAt(),
 			dto.userAccountDto().email(),
-			nickname
+			nickname,
+			dto.userAccountDto().userId()
 		);
 	}
 

--- a/src/main/java/com/fastcampus/boardproject/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcampus/boardproject/dto/response/ArticleWithCommentsResponse.java
@@ -15,11 +15,12 @@ public record ArticleWithCommentsResponse(
 		LocalDateTime createdAt,
 		String email,
 		String nickname,
+		String userId,
 		Set<ArticleCommentResponse> articleCommentsResponse
 ) {
 
-	public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-		return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+	public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+		return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
 	}
 
 	public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
@@ -36,6 +37,7 @@ public record ArticleWithCommentsResponse(
 			dto.createdAt(),
 			dto.userAccountDto().email(),
 			nickname,
+			dto.userAccountDto().userId(),
 			dto.articleCommentDtos().stream()
 				.map(ArticleCommentResponse::from)
 				.collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/fastcampus/boardproject/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/fastcampus/boardproject/dto/security/BoardPrincipal.java
@@ -1,0 +1,83 @@
+package com.fastcampus.boardproject.dto.security;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.fastcampus.boardproject.domain.UserAccount;
+import com.fastcampus.boardproject.dto.UserAccountDto;
+
+import lombok.Getter;
+
+public record BoardPrincipal(
+	String username,
+	String password,
+	Collection<? extends GrantedAuthority> authorities,
+	String email,
+	String nickname,
+	String memo
+) implements UserDetails {
+
+	public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+		Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+		return new BoardPrincipal(
+			username,
+			password,
+			roleTypes.stream()
+					.map(RoleType::getName)
+					.map(SimpleGrantedAuthority::new)
+					.collect(Collectors.toUnmodifiableSet())
+			,
+			email,
+			nickname,
+			memo
+		);
+	}
+
+	public static BoardPrincipal from(UserAccountDto dto) {
+		return BoardPrincipal.of(
+			dto.userId(),
+			dto.userPassword(),
+			dto.email(),
+			dto.nickname(),
+			dto.memo()
+		);
+	}
+
+	public UserAccountDto toDto() {
+		return UserAccountDto.of(
+			username,
+			password,
+			email,
+			nickname,
+			memo
+		);
+	}
+
+
+	@Override public String getUsername() { return username; }
+	@Override public String getPassword() { return password; }
+	@Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+
+	@Override public boolean isAccountNonExpired() { return true; }
+	@Override public boolean isAccountNonLocked() { return true; }
+	@Override public boolean isCredentialsNonExpired() { return true; }
+	@Override public boolean isEnabled() { return true; }
+
+
+	public enum RoleType {
+		USER("ROLE_USER");
+
+		@Getter private final String name;
+
+		RoleType(String name) {
+			this.name = name;
+		}
+	}
+
+}

--- a/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
@@ -22,6 +22,8 @@ public interface ArticleCommentRepository extends
 
 	List<ArticleComment> findByArticle_Id(Long articleId);
 
+	void deleteByIdAndUserAccount_UserId(Long articleCommentId, String userId);
+
 	@Override
 	default void customize(QuerydslBindings bindings, QArticleComment root) {
 		bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
@@ -28,6 +28,8 @@ public interface ArticleRepository extends
 	Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
 	Page<Article> findByHashtag(String hashtag, Pageable pageable);
 
+	void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
+
 	@Override
 	default void customize(QuerydslBindings bindings, QArticle root) {
 		bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/fastcampus/boardproject/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/boardproject/service/ArticleCommentService.java
@@ -54,8 +54,8 @@ public class ArticleCommentService {
 		}
 	}
 
-	public void deleteArticleComment(Long articleCommentId) {
-		articleCommentRepository.deleteById(articleCommentId);
+	public void deleteArticleComment(Long articleCommentId, String userId) {
+		articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 	}
 
 }

--- a/src/main/java/com/fastcampus/boardproject/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/boardproject/service/ArticleService.java
@@ -65,17 +65,20 @@ public class ArticleService {
 	public void updateArticle(Long articleId, ArticleDto dto) {
 		try {
 			Article article = articleRepository.getReferenceById(articleId);
+			UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
 
-			if (dto.title() != null) { article.setTitle(dto.title()); }
-			if (dto.content() != null) { article.setContent(dto.content()); }
-			article.setHashtag(dto.hashtag());
+			if (article.getUserAccount().equals(userAccount)) {
+				if (dto.title() != null) { article.setTitle(dto.title()); }
+				if (dto.content() != null) { article.setContent(dto.content()); }
+				article.setHashtag(dto.hashtag());
+			}
 		} catch (EntityNotFoundException e) {
-			log.warn("게시글 업데이트 실패. 게시글을 찾을 수 없습니다. - dto: {}", dto);
+			log.warn("게시글 업데이트 실패. 게시글 수정에 필요한 정보를 찾을 수 없습니다. - {}", e.getLocalizedMessage());
 		}
 	}
 
-	public void deleteArticle(Long articleId) {
-		articleRepository.deleteById(articleId);
+	public void deleteArticle(Long articleId, String userId) {
+		articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
 	}
 
 	public long getArticleCount() {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,11 +2,11 @@
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('imhope', 'asdf1234', 'imhope', 'imhope@mail.com', 'I am imhope.', now(), 'imhope', now(), 'imhope')
+values ('imhope', '{noop}asdf1234', 'imhope', 'imhope@mail.com', 'I am imhope.', now(), 'imhope', now(), 'imhope')
 ;
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at,
                           modified_by)
-values ('imhappy', 'asdf1234', 'imhappy', 'imhappy@mail.com', 'I am imhappy.', now(), 'imhappy', now(), 'imhappy')
+values ('imhappy', '{noop}asdf1234', 'imhappy', 'imhappy@mail.com', 'I am imhappy.', now(), 'imhappy', now(), 'imhappy')
 ;
 
 -- 123 게시글

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -74,19 +74,24 @@
                                         성공한 사람이 되려고 노력하기보다 가치있는 사람이 되려고 노력하라. – 알버트 아인슈타인
                                     </p>
                                 </div>
-                                <div class="col-2 mb-3">
+                                <div class="col-2 mb-3 align-self-center">
                                     <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                                 </div>
                             </div>
                         </form>
                     </li>
                     <li>
-                        <div>
-                            <strong>imhappy</strong>
-                            <small><time>2023-03-26</time></small>
-                            <p>
-                                내게 능력 주시는 자 안에서 내가 모든 것을 할 수 있다!
-                            </p>
+                        <div class="row">
+                            <div class="col-md-10 col-lg-9">
+                                <strong>imhappy</strong>
+                                <small><time>2023-03-26</time></small>
+                                <p>
+                                    내게 능력 주시는 자 안에서 내가 모든 것을 할 수 있다!
+                                </p>
+                            </div>
+                            <div class="col-2 mb-3 align-self-center">
+                                <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
+                            </div>
                         </div>
                     </li>
                 </ul>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -11,7 +11,7 @@
         <attr sel="#hashtag" th:text="*{hashtag}" />
         <attr sel="#article-content/pre" th:text="*{content}" />
 
-        <attr sel="#article-buttons">
+        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
@@ -29,6 +29,7 @@
                 <attr sel="div/strong" th:text="${articleComment.nickname}" />
                 <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yy-MM-dd HH:mm:ss')}" />
                 <attr sel="div/p" th:text="${articleComment.content}" />
+                <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
             </attr>
         </attr>
     </attr>
@@ -36,7 +37,7 @@
     <attr sel="#pagination">
         <attr sel="li[0]/a"
               th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
-              th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+              th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
         />
         <attr sel="li[1]/a"
               th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -7,7 +7,7 @@
 
     <attr sel="#article-form" th:action="${formStatus.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
-        <attr sel="#content" th:value="${article?.content} ?: _" />
+        <attr sel="#content" th:text="${article?.content} ?: _" />
         <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -53,7 +53,7 @@
             </attr>
         </attr>
 
-        <attr sel="#write-article" th:href="@{/articles/form}" />
+        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -15,8 +15,9 @@
                 </ul>
 
                 <div class="text-end">
-                    <button type="button" class="btn btn-outline-light me-2">Login</button>
-                    <button type="button" class="btn btn-warning">Sing-up</button>
+                    <span id="username" class="tet-white me-2">username</span>
+                    <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
+                    <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -2,4 +2,7 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
 </thlogic>

--- a/src/test/java/com/fastcampus/boardproject/config/TestSecurityConfig.java
+++ b/src/test/java/com/fastcampus/boardproject/config/TestSecurityConfig.java
@@ -1,0 +1,30 @@
+package com.fastcampus.boardproject.config;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import com.fastcampus.boardproject.domain.UserAccount;
+import com.fastcampus.boardproject.repository.UserAccountRepository;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+	@MockBean private UserAccountRepository userAccountRepository;
+
+	@BeforeTestMethod
+	public void securitySetup() {
+		given(userAccountRepository.findById(anyString())).willReturn(Optional.of(UserAccount.of(
+				"imhopeTest",
+				"pw",
+				"imhope-test@mail.com",
+				"imhope-test",
+				"test-memo"
+		)));
+	}
+
+}

--- a/src/test/java/com/fastcampus/boardproject/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/fastcampus/boardproject/controller/ArticleCommentControllerTest.java
@@ -18,16 +18,18 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.fastcampus.boardproject.config.SecurityConfig;
+import com.fastcampus.boardproject.config.TestSecurityConfig;
 import com.fastcampus.boardproject.dto.ArticleCommentDto;
 import com.fastcampus.boardproject.dto.request.ArticleCommentRequest;
 import com.fastcampus.boardproject.service.ArticleCommentService;
 import com.fastcampus.boardproject.util.FormDataEncoder;
 
 @DisplayName("View 컨트롤러 - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
 
@@ -45,6 +47,7 @@ class ArticleCommentControllerTest {
 	}
 
 
+	@WithUserDetails(value = "imhopeTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
 	@DisplayName("[view][POST] 댓글 등록 - 정상 호출")
 	@Test
 	void givenArticleCommentInfo_whenRequesting_thenSavesNewArticleComment() throws Exception {
@@ -66,13 +69,15 @@ class ArticleCommentControllerTest {
 		then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
 	}
 
+	@WithUserDetails(value = "imhopeTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
 	@DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
 	@Test
 	void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
 		// Given
 		Long articleId = 1L;
 		Long articleCommentId = 1L;
-		willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId);
+		String userId = "imhopeTest";
+		willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
 		// When & Then
 		mvc.perform(
@@ -84,7 +89,7 @@ class ArticleCommentControllerTest {
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/articles/" + articleId))
 			.andExpect(redirectedUrl("/articles/" + articleId));
-		then(articleCommentService).should().deleteArticleComment(articleCommentId);
+		then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
 	}
 
 }

--- a/src/test/java/com/fastcampus/boardproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/boardproject/repository/JpaRepositoryTest.java
@@ -3,21 +3,25 @@ package com.fastcampus.boardproject.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.fastcampus.boardproject.config.JpaConfig;
 import com.fastcampus.boardproject.domain.Article;
 import com.fastcampus.boardproject.domain.UserAccount;
 
 @ActiveProfiles("testdb")
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
@@ -95,4 +99,15 @@ class JpaRepositoryTest {
 		assertThat(articleRepository.count()).isEqualTo(previousArticleCount - 1);
 		assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deletedCommentsSize);
 	}
+
+
+	@EnableJpaAuditing
+	@TestConfiguration
+	public static class TestJpaConfig {
+		@Bean
+		public AuditorAware<String> auditorAware() {
+			return () -> Optional.of("imhope");
+		}
+	}
+
 }

--- a/src/test/java/com/fastcampus/boardproject/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/fastcampus/boardproject/service/ArticleCommentServiceTest.java
@@ -129,13 +129,14 @@ class ArticleCommentServiceTest {
 	void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
 		// Given
 		Long articleCommentId = 1L;
-		willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+		String userId = "imhope";
+		willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 
 		// When
-		sut.deleteArticleComment(articleCommentId);
+		sut.deleteArticleComment(articleCommentId, userId);
 
 		// Then
-		then(articleCommentRepository).should().deleteById(articleCommentId);
+		then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 	}
 
 

--- a/src/test/java/com/fastcampus/boardproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/boardproject/service/ArticleServiceTest.java
@@ -199,6 +199,7 @@ class ArticleServiceTest {
 		Article article = createArticle();
 		ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#springboot");
 		given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+		given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(dto.userAccountDto().toEntity());
 
 		// When
 		sut.updateArticle(dto.id(), dto);
@@ -209,6 +210,7 @@ class ArticleServiceTest {
 			.hasFieldOrPropertyWithValue("content", dto.content())
 			.hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
 		then(articleRepository).should().getReferenceById(dto.id());
+		then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
 	}
 
 	@DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
@@ -230,13 +232,14 @@ class ArticleServiceTest {
 	void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
 		// Given
 		Long articleId = 1L;
-		willDoNothing().given(articleRepository).deleteById(articleId);
+		String userId = "imhope";
+		willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
 
 		// When
-		sut.deleteArticle(1L);
+		sut.deleteArticle(1L, userId);
 
 		// Then
-		then(articleRepository).should().deleteById(articleId);
+		then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
 	}
 
 	@DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다.")


### PR DESCRIPTION
### 인증 기능의 실제 뷰 구현 & 리팩토링

* 시큐리티 설정과 자바 대응 코드 구현
   * 인증이 필요한 페이지와 그렇지 않은 페이지 설정
   * `static resource`인 `css`, `js`를 `WebSecurityCustomizer`를 `ben`으로 등록해서 설정할 수 있지만, 이렇게 되면 `Spring Security`의 관리를 받을 수 없으므로 `SecurityFilterChain` 안에서 설정한다. -> `Spring Security`의 관리를 받을 수 있다.

* 패스워드 인코더가 인식할 수 있도록 패스워드 정보 수정(`data.sql`)
   * 미리 `data.sql`에 작성해둔 `UserAccount` 정보에는 패스워드 인코더가 인식할 수 있는 정보가 없다. 패스워드를 인코딩하지 않으려면 `NoOpPasswordEncoder`를 사용한다. 이를 위해서 `data.sql`에 작성된 패스워드 앞에 `{noop}` 식별자를 추가한다.

* 수정, 삭제를 할 때 해당 사용자가 맞는지 확인하기 위한 응답 정보 추가
   * `responseDto`에 `userId`가 포함되어 있지 않다. 하지만 `Spring Security`를 사용하면서, 인증 정보의 `userId`와 게시글/댓글의 작성자 `userId`가 동일한지 알기 위해서 `responseDto`에 `userId`가 필요하다. 따라서 `responseDto`에 `userId`를 추가한다.

* 인증 기능의 뷰 연결 및 리팩토링
   * 인증 기능 
      * 인증 여부에 따른 변경 사항
         * 헤더
            * 로그인/로그아웃 버튼 보임/숨김
            * 로그인 후 이름 보임
         * 게시판
            * 글 작성 버튼 보임/숨김
      * 인증 정보와 게시글/댓글 정보가 일치 여부에 따른 변경 사항
         * 글 수정/삭제 버튼 보임/숨김
         * 댓글 삭제 버튼 보임/숨김
   * 리팩토링
      * 게시글 페이징 처리 오류 발견
         * `prev` 버튼의 thymeleaf 문법의 오류 변경 → `*{id} - 1 <= 0`
      * 게시글 수정 페이지 오류 발견
         * 게시글 수정 페이지에 들어가면, 게시글의 본문이 보이지 않는 오류가 있다. → thymeleaf 문법에서 `textarea`에 `th:value`를 작성한 것을 발견했다. `textarea`에는 `th:value`가 아니라 `th:text`로 설정해야 한다.

* `Entity`의 `equals()`가 올바르게 `id`를 비교할 수 있도록 수정
   * 게시글 수정이 올바르게 작동되지 않는다는 것을 발견했다. 컨트롤러와 서비스의 문제가 아닌, `Entity`의 `equals()` 메서드가 잘못 설정되어 있었기 때문이다. `Article`, `ArticleComment`, `UserAccount` 모두 수정이 필요하며, `equals()`의 비교대상을 올바른 `getter`로 수정한다.


This closes #46 