### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB → JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,7 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_UR}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
clearDB 의 기본 mySQL 버전이 `5.6`으로 너무 낮기 때문에, 문제가 발생한 것을 확인했다. (`5.6` 버전에서는 `article_comment.content` 인덱스 사이즈가 너무 큼)
따라서 ClearDB의 대안으로 JawsDB 로 변경한다.

기본 mySQL 버전 `8.0`
이를 이용해서 환경변수를 다시 작업한다.

* https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
* https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup