### PR TITLE
#63 - 리팩토링: 엔티티 연관관계 필드 줄바꿈 변경

### DIFF
--- a/src/main/java/com/fastcampus/boardproject/domain/Article.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/Article.java
@@ -35,7 +35,10 @@ public class Article extends AuditingFields {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+	@Setter
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "userId")
+	private UserAccount userAccount; // 유저 정보 (ID)
 
 	@Setter @Column(nullable = false) private String title; // 제목
 	@Setter @Column(nullable = false, length = 10000) private String content; // 본문

--- a/src/main/java/com/fastcampus/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/ArticleComment.java
@@ -29,8 +29,13 @@ public class ArticleComment extends AuditingFields {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Setter @ManyToOne(optional = false) private Article article; // 게시글 (ID)
-	@Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+	@Setter
+	@ManyToOne(optional = false)
+	private Article article; // 게시글 (ID)
+	@Setter
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "userId")
+	private UserAccount userAccount; // 유저 정보 (ID)
 
 	@Setter @Column(nullable = false, length = 500) private String content; // 본문
 

--- a/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
@@ -21,12 +21,15 @@ import lombok.ToString;
 @Entity
 public class UserAccount extends AuditingFields {
 
-	@Id @Column(length = 50) private String userId;
+	@Id
+	@Column(length = 50)
+	private String userId;
+	
 	@Setter @Column(nullable = false) private String userPassword;
 
 	@Setter @Column(length = 100) private String email;
 	@Setter @Column(length = 100) private String nickname;
-	private String memo;
+	@Setter private String memo;
 
 
 	protected UserAccount() {


### PR DESCRIPTION
`PR`로 연관관계 필드의 코드 스타일을 간단하게 정리한다.

This closes #63 